### PR TITLE
Count only unique warnings

### DIFF
--- a/lib/warning_counter.rb
+++ b/lib/warning_counter.rb
@@ -19,7 +19,7 @@ class WarningCounter < XCPretty::Simple
   end
 
   def format_compile_warning(file_name, file_path, reason, line, cursor)
-    key = "#{file_path}:#{reason}:#{line}:#{cursor}"
+    key = "#{file_path}:#{reason}:#{line}"
     if not @warnings_hash.include?(key) 
       @warnings_hash.add(key)
       @warning_count += 1

--- a/lib/warning_counter.rb
+++ b/lib/warning_counter.rb
@@ -4,6 +4,7 @@ require 'psych'
 class WarningCounter < XCPretty::Simple
   def initialize(use_unicode, colorize)
     super
+    @warnings_hash = Set.new()
     @warning_count = 0
   end
 
@@ -18,7 +19,11 @@ class WarningCounter < XCPretty::Simple
   end
 
   def format_compile_warning(file_name, file_path, reason, line, cursor)
-    @warning_count += 1
+    key = "#{file_path}:#{reason}:#{line}:#{cursor}"
+    if not @warnings_hash.include?(key) 
+      @warnings_hash.add(key)
+      @warning_count += 1
+    end  
     super
   end
 


### PR DESCRIPTION
In case if header file contains direct warning directive

```
// SomeFile.h
#warning something is not right
```

This warning will be counted multiple times
Adding hash for warnings allows to be more precise about warnings cout to what Xcode says.
Still, this method counts few additional stuff in comparison to Xcode, but still, currently it returns bit more realistic values
